### PR TITLE
Add navigation from login to dashboard home

### DIFF
--- a/app/src/main/java/com/sandoval/baubaplogin/MainActivity.kt
+++ b/app/src/main/java/com/sandoval/baubaplogin/MainActivity.kt
@@ -9,7 +9,12 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.sandoval.baubaplogin.ui.screens.login.LoginScreen
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.rememberNavController
+import com.sandoval.baubaplogin.ui.screens.navigation.NavigationRoutes
+import com.sandoval.baubaplogin.ui.screens.navigation.authenticatedGraph
+import com.sandoval.baubaplogin.ui.screens.navigation.unauthenticatedGraph
 import com.sandoval.baubaplogin.ui.theme.BaubapLoginTheme
 
 class MainActivity : ComponentActivity() {
@@ -29,7 +34,22 @@ fun BaubaApp() {
         modifier = Modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background
     ) {
-        LoginScreen()
+        MainBaubapAppNavHost()
+    }
+}
+
+@Composable
+fun MainBaubapAppNavHost(
+    modifier: Modifier = Modifier,
+    navController: NavHostController = rememberNavController(),
+) {
+    NavHost(
+        modifier = modifier,
+        navController = navController,
+        startDestination = NavigationRoutes.Unauthenticated.NavigationRoute.route
+    ) {
+        unauthenticatedGraph(navController = navController)
+        authenticatedGraph(navController = navController)
     }
 }
 

--- a/app/src/main/java/com/sandoval/baubaplogin/ui/screens/login/LoginScreen.kt
+++ b/app/src/main/java/com/sandoval/baubaplogin/ui/screens/login/LoginScreen.kt
@@ -1,6 +1,5 @@
 package com.sandoval.baubaplogin.ui.screens.login
 
-import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -33,6 +32,7 @@ import com.sandoval.baubaplogin.ui.theme.BaubapLoginTheme
 @Composable
 fun LoginScreen(
     loginViewModel: LoginViewModel = viewModel(),
+    onNavigateToAuthenticatedRoute: () -> Unit,
 ) {
 
     val loginState by remember {
@@ -48,8 +48,7 @@ fun LoginScreen(
          * que el login sea satisfactorio
          */
         LaunchedEffect(key1 = true) {
-            Toast.makeText(currentContext, "Logged in", Toast.LENGTH_SHORT)
-                .show()
+            onNavigateToAuthenticatedRoute.invoke()
         }
     } else {
         Column(
@@ -154,6 +153,6 @@ fun LoginScreen(
 @Composable
 fun PreviewLoginScreen() {
     BaubapLoginTheme {
-        LoginScreen()
+        LoginScreen(onNavigateToAuthenticatedRoute = {})
     }
 }

--- a/app/src/main/java/com/sandoval/baubaplogin/ui/screens/navigation/NavigationRoutes.kt
+++ b/app/src/main/java/com/sandoval/baubaplogin/ui/screens/navigation/NavigationRoutes.kt
@@ -1,0 +1,13 @@
+package com.sandoval.baubaplogin.ui.screens.navigation
+
+sealed class NavigationRoutes {
+    sealed class Unauthenticated(val route: String) : NavigationRoutes() {
+        object NavigationRoute : Unauthenticated(route = "unauthenticated")
+        object Login : Unauthenticated(route = "login")
+    }
+
+    sealed class Authenticated(val route: String) : NavigationRoutes() {
+        object NavigationRoute : Authenticated(route = "authenticated")
+        object DashboardHome : Authenticated(route = "dashboard_home")
+    }
+}

--- a/app/src/main/java/com/sandoval/baubaplogin/ui/screens/navigation/NestedNavigations.kt
+++ b/app/src/main/java/com/sandoval/baubaplogin/ui/screens/navigation/NestedNavigations.kt
@@ -1,0 +1,43 @@
+package com.sandoval.baubaplogin.ui.screens.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import androidx.navigation.navigation
+import com.sandoval.baubaplogin.ui.screens.dashboard_home.DashBoardHomeScreen
+import com.sandoval.baubaplogin.ui.screens.login.LoginScreen
+
+/**
+ * Pantalla de Login
+ */
+fun NavGraphBuilder.unauthenticatedGraph(navController: NavController) {
+    navigation(
+        route = NavigationRoutes.Unauthenticated.NavigationRoute.route,
+        startDestination = NavigationRoutes.Unauthenticated.Login.route
+    ) {
+        composable(route = NavigationRoutes.Unauthenticated.Login.route) {
+            LoginScreen(onNavigateToAuthenticatedRoute = {
+                navController.navigate(route = NavigationRoutes.Authenticated.NavigationRoute.route) {
+                    popUpTo(route = NavigationRoutes.Unauthenticated.NavigationRoute.route) {
+                        inclusive = true
+                    }
+                }
+            })
+        }
+    }
+}
+
+
+/**
+ * Pantalla del dashboard home
+ */
+fun NavGraphBuilder.authenticatedGraph(navController: NavController) {
+    navigation(
+        route = NavigationRoutes.Authenticated.NavigationRoute.route,
+        startDestination = NavigationRoutes.Authenticated.DashboardHome.route
+    ) {
+        composable(route = NavigationRoutes.Authenticated.DashboardHome.route) {
+            DashBoardHomeScreen()
+        }
+    }
+}


### PR DESCRIPTION
- Create the sealed class that will handle the auth and unauth state to retrieve the correct navigation graph
- Create the nested navigation regarding the navigation route that the app should take. This will depend on the state: auth or unauth
- Add the navigate to auth state on the login screen
- Add the nav host graph to the mainactivity class to be executed on the main app initialization